### PR TITLE
Quick fix to prevent generated SQL queries to throw an Exception when trying to access online customers and visitors stats when having IPv6 addresses whitelisted in maintenance mode

### DIFF
--- a/statslive.php
+++ b/statslive.php
@@ -60,7 +60,7 @@ class statslive extends Module
     private function getCustomersOnline()
     {
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_diff(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))), [false]));
+            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips)))));
         }
 
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {
@@ -101,7 +101,7 @@ class statslive extends Module
     private function getVisitorsOnline()
     {
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_diff(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))), [false]));
+            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips)))));
         }
 
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {

--- a/statslive.php
+++ b/statslive.php
@@ -60,7 +60,7 @@ class statslive extends Module
     private function getCustomersOnline()
     {
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))));
+            $maintenance_ips = implode(',', array_diff(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))), [false]));
         }
 
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {
@@ -101,7 +101,7 @@ class statslive extends Module
     private function getVisitorsOnline()
     {
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_map('ip2long', array_filter(array_map('trim', explode(',', $maintenance_ips)))));
+            $maintenance_ips = implode(',', array_diff(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))), [false]));
         }
 
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {


### PR DESCRIPTION
This is just a quickfix to prevent generating exceptions when trying to access online customers and visitors stats when having IPv6 addresses whitelisted in maintenance mode.

The (quick)fix will basically ignore all IPv6 in the generated SQL query because **ip2long** only supports IPv4.

It means that the stats about online persons will count any logged admin having an IPv6 as connected but will not throw.